### PR TITLE
Missing require added

### DIFF
--- a/src/clj/titanoboa/system/local.clj
+++ b/src/clj/titanoboa/system/local.clj
@@ -6,7 +6,8 @@
             [titanoboa.actions :as actions]
             [titanoboa.processor :as processor]
             [titanoboa.database :as db]
-            [titanoboa.cache :as cache]))
+            [titanoboa.cache :as cache]
+            [titanoboa.repo :as repo]))
 
 (defn local-core-system [{:keys [node-id jobs-repo-path job-folder-path  new-jobs-chan jobs-chan finished-jobs-chan eviction-interval eviction-age] :as config}]
   (component/system-map


### PR DESCRIPTION
Following the getting started steps for local setup https://github.com/mikub/titanoboa#-develop--test-workflows-locally-in-your-clojure-repl starting `lein repl` will fail with following message:
```
$ lein repl 
#error {
 :cause titanoboa.repo
 :via
 [{:type clojure.lang.Compiler$CompilerException
   :message Syntax error compiling at (titanoboa/system/local.clj:21:21).
   :data #:clojure.error{:phase :compile-syntax-check, :line 21, :column 21, :source titanoboa/system/local.clj}
   :at [clojure.lang.Compiler analyzeSeq Compiler.java 7114]}
  {:type java.lang.ClassNotFoundException
   :message titanoboa.repo
   :at [java.net.URLClassLoader findClass URLClassLoader.java 381]}]
 :trace
 [[java.net.URLClassLoader findClass URLClassLoader.java 381]
  [clojure.lang.DynamicClassLoader findClass DynamicClassLoader.java 69]
  [java.lang.ClassLoader loadClass ClassLoader.java 424]
  [clojure.lang.DynamicClassLoader loadClass DynamicClassLoader.java
```

I believe this is caused by missing require not being loaded (outside of normal execution) and explicitly referenced by fully qualified namespace name.
This PR adds the missing require.
