### PR TITLE
Add support for tenant id

### DIFF
--- a/db-setup/20220407113600-add-tenant-column.up.sql
+++ b/db-setup/20220407113600-add-tenant-column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS tenantid text;
+
+CREATE INDEX IF NOT EXISTS jobs_tenantid_jobdef_idx ON jobs (tenantid, jobdef);

--- a/src/clj/titanoboa/database.clj
+++ b/src/clj/titanoboa/database.clj
@@ -62,6 +62,7 @@
   (jdbc/insert! ds "jobs" {:jobid     (java.util.UUID/fromString (:jobid job))
                            :jobdef    (get-in job [:jobdef :name])
                            :revision  (get-in job [:jobdef :revision])
+                           :tenantid  (:tenant-id job)
                            :state     (name (:state job))
                            :start     (t/to-sql-time (:start job))
                            :ended     (t/to-sql-time  (:end job))
@@ -76,7 +77,7 @@
 (defmulti list-jobs
           "Retrieve list of archived jobs. The jobs are not to be containing all data - only a short map with :jobid :jobdef :revision :state :start :ended :stepid :steptype :stepstate!
           Returns a map in a format of  {:offset offset :limit limit :totalcount total-number-of-rows-available :values [{job 1} {job 2} {job n}]}"
-          (fn [ds limit offset order] (.getDriverClass (:datasource ds))))
+          (fn [ds limit offset order filters] (.getDriverClass (:datasource ds))))
 
 
 (defn get-job [ds jobid]


### PR DESCRIPTION
This PR adds support for tenant id - i.e. enables jobs to be run with an assigned tentat-id  and it also enables filtering of archived workflow jobs based on not only the tenant-id, but also on workflow definition name.

E.g. now I can start a new workflow job of `demo` workflow:
```
http://localhost:3449/systems/core/jobs/demo?tenant-id=111
```

And I can then also search for all jobs of this tenant:
```
http://localhost:3449/archive/jobs?limit=50&offset=0&order-by=start&order=desc&tenant-id=111
```

**Note**: this PR also includes a DDL statements that have to be run to update the DB schema